### PR TITLE
Fixed incorrect type import in Typescript

### DIFF
--- a/src/codegen/typescript.rs
+++ b/src/codegen/typescript.rs
@@ -9,7 +9,7 @@ pub fn render(spec: OpenApiSpec) -> Result<CodegenBuf, Box<dyn Error>> {
     buf.writeln("");
 
     for name in spec.unmanaged_schemas {
-        buf.writeln(format!("import {name} from '../index';"));
+        buf.writeln(format!("import {{ {name} }} from '../index';"));
     }
     buf.writeln("");
 


### PR DESCRIPTION
Fixed error where we are using the default import (ends up with the type as the `Turbopuffer` client)

### Old
```
import Bm25ClauseParams from '../index';
import ContainsAllTokensFilterParams from '../index';
import ContainsAnyTokenFilterParams from '../index';
```

### New
```
import { Bm25ClauseParams } from '../index';
import { ContainsAllTokensFilterParams } from '../index';
import { ContainsAnyTokenFilterParams } from '../index';
```