### PR TITLE
codegen: extract compute_inherits + rewrite_single_field_objects_to_tuples to shared

### DIFF
--- a/src/codegen/java.rs
+++ b/src/codegen/java.rs
@@ -12,8 +12,10 @@ use crate::{
 pub fn render(mut spec: OpenApiSpec) -> Result<CodegenBuf, Box<dyn Error>> {
     shared::extract_any_of_tuples(&mut spec.managed_schemas, ConflictBehavior::AppendSuffix)?;
     let ctx = RenderCtx {
-        inherits: compute_inherits(&spec.managed_schemas)?,
-        objects_as_tuples: rewrite_single_field_objects_to_tuples(&mut spec.managed_schemas)?,
+        inherits: shared::compute_inherits(&spec.managed_schemas)?,
+        objects_as_tuples: shared::rewrite_single_field_objects_to_tuples(
+            &mut spec.managed_schemas,
+        )?,
         schemas: spec.managed_schemas,
     };
 
@@ -56,74 +58,6 @@ struct RenderCtx {
     /// overrides for the fields.
     objects_as_tuples: BTreeMap<String, BTreeMap<String, String>>,
     schemas: BTreeMap<String, OpenApiSchema>,
-}
-
-fn compute_inherits(
-    schemas: &BTreeMap<String, OpenApiSchema>,
-) -> Result<BTreeMap<String, String>, Box<dyn Error>> {
-    let mut result = BTreeMap::new();
-    for (name, schema) in schemas {
-        match schema {
-            OpenApiSchema::AnyOf {
-                _description: _,
-                any_of,
-            } => {
-                for schema in any_of {
-                    if let OpenApiSchema::Ref { sref, .. } = schema {
-                        let sref = strip_schema_ref_prefix(sref)?;
-                        let existing = result.insert(sref.into(), name.into());
-                        if let Some(existing) = existing {
-                            Err(format!(
-                                "duplicate inheritance for {sref}: {existing} and {name}"
-                            ))?
-                        }
-                    }
-                }
-            }
-            _ => (),
-        }
-    }
-    Ok(result)
-}
-
-fn rewrite_single_field_objects_to_tuples(
-    schemas: &mut BTreeMap<String, OpenApiSchema>,
-) -> Result<BTreeMap<String, BTreeMap<String, String>>, Box<dyn Error>> {
-    let mut names = BTreeMap::new();
-    for (name, schema) in schemas {
-        match schema {
-            OpenApiSchema::Object {
-                _description: _,
-                _type: _,
-                properties,
-                required,
-                title: _,
-            } if properties.len() == 1 && required.len() == 1 => {
-                let (prop_name, prop_schema) = properties.into_iter().next().unwrap();
-                if !required.contains(prop_name) {
-                    continue;
-                }
-                let prop_name = prop_name.clone();
-                let prop_name_munged = shared::snake_to_camel_case(&prop_name);
-                if let Some(title) = prop_schema.title_mut() {
-                    *title = Some(prop_name_munged.clone());
-                }
-                *schema = OpenApiSchema::ArrayTuple {
-                    prefix_items: vec![prop_schema.clone()],
-                    _description: None,
-                    _type: Default::default(),
-                    additional_items: false,
-                    x_turbopuffer_variant_name: None,
-                    x_turbopuffer_variant_drop_on_conflict: false,
-                    title: None,
-                };
-                let overrides = BTreeMap::from([(prop_name_munged, prop_name)]);
-                names.insert(name.clone(), overrides);
-            }
-            _ => (),
-        }
-    }
-    Ok(names)
 }
 
 fn render_schema_top_level(

--- a/src/codegen/shared.rs
+++ b/src/codegen/shared.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, error::Error, mem};
 
-use crate::codegen::{OpenApiSchema, SCHEMA_REF_PREFIX};
+use crate::codegen::{OpenApiSchema, SCHEMA_REF_PREFIX, strip_schema_ref_prefix};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ConflictBehavior {
@@ -196,6 +196,76 @@ pub fn snake_to_camel_case(input: &str) -> String {
         }
     }
     s
+}
+
+/// For each `anyOf`-of-`$ref` schema, records which variant inherits from
+/// which abstract base. The result maps each variant schema's name to its
+/// enclosing union's name.
+pub fn compute_inherits(
+    schemas: &BTreeMap<String, OpenApiSchema>,
+) -> Result<BTreeMap<String, String>, Box<dyn Error>> {
+    let mut result = BTreeMap::new();
+    for (name, schema) in schemas {
+        let OpenApiSchema::AnyOf { any_of, .. } = schema else {
+            continue;
+        };
+        for item in any_of {
+            let OpenApiSchema::Ref { sref, .. } = item else {
+                continue;
+            };
+            let sref = strip_schema_ref_prefix(sref)?;
+            if let Some(existing) = result.insert(sref.into(), name.into()) {
+                Err(format!(
+                    "duplicate inheritance for {sref}: {existing} and {name}"
+                ))?
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// Rewrites object schemas with a single required field as 1-tuples, returning
+/// a map from each rewritten schema's name to a `pascal -> original` JSON
+/// property-name override map (so emitters that serialize tuples as objects
+/// can recover the original key).
+pub fn rewrite_single_field_objects_to_tuples(
+    schemas: &mut BTreeMap<String, OpenApiSchema>,
+) -> Result<BTreeMap<String, BTreeMap<String, String>>, Box<dyn Error>> {
+    let mut names = BTreeMap::new();
+    for (name, schema) in schemas {
+        let OpenApiSchema::Object {
+            properties,
+            required,
+            ..
+        } = schema
+        else {
+            continue;
+        };
+        if properties.len() != 1 || required.len() != 1 {
+            continue;
+        }
+        let (prop_name, prop_schema) = properties.iter().next().unwrap();
+        if !required.contains(prop_name) {
+            continue;
+        }
+        let prop_name = prop_name.clone();
+        let prop_name_munged = snake_to_camel_case(&prop_name);
+        let mut prop_schema = prop_schema.clone();
+        if let Some(title) = prop_schema.title_mut() {
+            *title = Some(prop_name_munged.clone());
+        }
+        *schema = OpenApiSchema::ArrayTuple {
+            prefix_items: vec![prop_schema],
+            _description: None,
+            _type: Default::default(),
+            additional_items: false,
+            x_turbopuffer_variant_name: None,
+            x_turbopuffer_variant_drop_on_conflict: false,
+            title: None,
+        };
+        names.insert(name.clone(), BTreeMap::from([(prop_name_munged, prop_name)]));
+    }
+    Ok(names)
 }
 
 pub fn camel_to_snake_case(input: &str) -> String {


### PR DESCRIPTION
Both helpers were going to be duplicated, character-for-character, between the existing `java.rs` target and a future `csharp.rs` target. Pull them into `shared` up front so the next language to land doesn't need its own copy.

This PR lands the helpers and rewires `java.rs` to use them; nothing in the current tree calls them apart from `java.rs`. The C# target on `claude/improve-csharp-sdk-e0fB7` keeps its own local copies for now and will pick up `shared::` after this merges.

## Verification

Captured the Java output against the current spec hash (`turbopuffer-d1a77644…dc613856c.yml`) before the refactor, and confirmed `diff` reports zero changes after:

```
Java: identical
```

Net diff: +75 / –71.