### PR TITLE
codegen: add RerankBy to TYPE_PREFIXES

### DIFF
--- a/src/codegen/csharp.rs
+++ b/src/codegen/csharp.rs
@@ -509,9 +509,7 @@ fn render_any_of_refs(
     // pinned onto the concrete subtypes via JsonConverterAttribute.
     buf.writeln("public override bool CanConvert(Type typeToConvert) =>");
     buf.indent();
-    buf.writeln(format!(
-        "typeof({name}).IsAssignableFrom(typeToConvert);"
-    ));
+    buf.writeln(format!("typeof({name}).IsAssignableFrom(typeToConvert);"));
     buf.unindent();
     buf.writeln("");
     buf.writeln(format!(

--- a/src/codegen/shared.rs
+++ b/src/codegen/shared.rs
@@ -323,7 +323,8 @@ pub fn assign_generics(schemas: &mut [OpenApiSchema]) -> Vec<&'static str> {
                 if let OpenApiSchema::Any { .. } = &**items {
                     // NOTE: it's a bit of a hack to jam this into the
                     // `description` field, but it's very convenient.
-                    *description = Some(format!("{GENERIC_DESCRIPTION_PREFIX}{}", GENERICS[*index]));
+                    *description =
+                        Some(format!("{GENERIC_DESCRIPTION_PREFIX}{}", GENERICS[*index]));
                     *index += 1;
                 } else {
                     assign(index, items);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,14 @@ use crate::codegen::OpenApiSpec;
 mod codegen;
 mod util;
 
-const TYPE_PREFIXES: &[&str] = &["Aggregate", "Expr", "Filter", "GroupBy", "RankBy"];
+const TYPE_PREFIXES: &[&str] = &[
+    "Aggregate",
+    "Expr",
+    "Filter",
+    "GroupBy",
+    "RankBy",
+    "RerankBy",
+];
 
 #[derive(Parser)]
 struct Args {


### PR DESCRIPTION
To get clean support for `rerank_by` in the SDKs, I believe we need to give it the same treatment as `rank_by` here.

Corresponding openapi spec update: https://github.com/turbopuffer/turbopuffer/pull/9238